### PR TITLE
Add viresclient to Projects.

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -323,3 +323,11 @@
   logo: https://avatars3.githubusercontent.com/u/22352442?s=460&v=4
   contact: "Bryan Harter"
   keywords: ["solar","magnetosphere","ionosphere_thermosphere_mesosphere","general"]
+
+- name: "viresclient"
+  code: "https://github.com/ESA-VirES/VirES-Python-Client/"
+  docs: "https://viresclient.readthedocs.io/"
+  url: "https://vires.services/"
+  description: "Access to Swarm products"
+  contact: "EOX IT Services, Ashley Smith"
+  keywords: ["magnetosphere", "ionosphere_thermosphere_mesosphere", "data_retrieval", "webservice", "data_access"]


### PR DESCRIPTION
This package provides access to the ESA Swarm mission data and models. It's part of a larger Server/client architecture "VirES" supported by ESA principally for Swarm, though could evolve to other datasets in the future (VirES for Aeolus is in development). GUI access is at https://vires.services and there is also now a free "Virtual Research Environment" at https://vre.vires.services (a JupyterHub deployment) where we plan to provide ready-to-run notebooks soon.

The server can provide flexible access to time series of most of the Swarm products, together with on-demand evaluation of geomagnetic field models. viresclient accesses this server and returns requested data as pandas or xarray objects.